### PR TITLE
flip histograms + fix nb of samples bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixed
 
 - Edges toolTips properly close when the mouse goes out.
+- Histogram bars have the right amount of samples they contain.
+
+## Updated
+
+- Histogram plots are 90° rotated.
 
 ## [0.0.21](https://github.com/craft-ai/react-craft-ai-components/compare/v0.0.20...v0.0.21) - 2019-04-10 ##
 

--- a/packages/react-craft-ai-decision-tree/stories/treeV2-classif-binary.json
+++ b/packages/react-craft-ai-decision-tree/stories/treeV2-classif-binary.json
@@ -915,7 +915,7 @@
           }
         ],
         "output_values": [
-          "Way too long class to say OFF",
+          "Reallyyyyyyy way too long class to say OFF",
           "ON"
         ],
         "x": 0,


### PR DESCRIPTION
Now the histograms are 90° rotated like this:
- All the legends can be shown
- We can have an infinite number of classes without squeezing the whole graph, we can just scroll along the vertical axis.

Bug fix:
 - The size of the node was not given in the Update function, now bars show the right nb of samples