### PR TITLE
fix controlled component | folded nodes were moving

### DIFF
--- a/packages/react-craft-ai-decision-tree/src/components/tree.jsx
+++ b/packages/react-craft-ai-decision-tree/src/components/tree.jsx
@@ -232,8 +232,8 @@ const Tree = React.memo(function Tree({
 
   // When the foldedNodes change, reapply them, and keep the root of the hierarchy at the same location.
   useEffect(() => applyFoldingAndFixPosition(foldedNodes, hierarchy), [
-    hierarchy,
-    foldedNodes
+    applyFoldingAndFixPosition,
+    hierarchy
   ]);
 
   const selectedHNode = useMemo(() => hNodeFromPath(selectedNode, hierarchy), [
@@ -247,11 +247,12 @@ const Tree = React.memo(function Tree({
       const folded = hNode.foldedChildren != null;
       const currentFoldedNodes = updateFoldedNodes ? foldedNodes : foldedNodesState;
       const newFoldedNodes = folded ? currentFoldedNodes.filter((path) => path !== hNode.path) : [...currentFoldedNodes, hNode.path];
+
+      applyFoldingAndFixPosition(newFoldedNodes, hNode);
       if (updateFoldedNodes) {
         updateFoldedNodes(newFoldedNodes);
       }
       else {
-        applyFoldingAndFixPosition(newFoldedNodes, hNode);
         setFoldedNodesState(newFoldedNodes);
       }
     },

--- a/packages/react-craft-ai-decision-tree/src/components/tree.jsx
+++ b/packages/react-craft-ai-decision-tree/src/components/tree.jsx
@@ -230,7 +230,8 @@ const Tree = React.memo(function Tree({
     [hierarchy]
   );
 
-  // When the foldedNodes change, reapply them, and keep the root of the hierarchy at the same location.
+  // Apply foldedNodes at the initialization and keep the root of the hierarchy at the same location.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => applyFoldingAndFixPosition(foldedNodes, hierarchy), [
     applyFoldingAndFixPosition,
     hierarchy


### PR DESCRIPTION
the function `applyFoldingAndFixPosition` was called according to the root and not to the node clicked when the component is controlled.
It is now called at the init but then `applyFoldingAndFixPosition` is called when nodes are folded only.